### PR TITLE
fix(v3): add --check-only and --dry-run flags to release script

### DIFF
--- a/v3/tasks/release/release.go
+++ b/v3/tasks/release/release.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -10,6 +11,13 @@ import (
 )
 
 const versionFile = "../../internal/version/version.txt"
+const changelogFile = "docs/src/content/docs/changelog.mdx"
+
+// Command-line flags
+var (
+	checkOnly bool
+	dryRun    bool
+)
 
 func checkError(err error) {
 	if err != nil {
@@ -18,18 +26,102 @@ func checkError(err error) {
 	}
 }
 
-// TODO:This can be replaced with "https://github.com/coreos/go-semver/blob/main/semver/semver.go"
-func updateVersion() string {
+// printUsage prints command-line usage information
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: release.go [--check-only] [--dry-run] [version]\n")
+	fmt.Fprintf(os.Stderr, "  --check-only  Check if unreleased content exists (exit 0 if yes, 1 if no)\n")
+	fmt.Fprintf(os.Stderr, "  --dry-run     Show what would be done without making changes\n")
+	fmt.Fprintf(os.Stderr, "  version       Specific version to release (optional, auto-increments if not specified)\n")
+	fmt.Fprintf(os.Stderr, "\nNote: --check-only exits immediately and ignores --dry-run if both are specified.\n")
+}
+
+// readVersion reads and validates the current version from the version file
+func readVersion() string {
 	currentVersionData, err := os.ReadFile(versionFile)
 	checkError(err)
-	currentVersion := string(currentVersionData)
+	currentVersion := strings.TrimSpace(string(currentVersionData))
+	if currentVersion == "" {
+		checkError(fmt.Errorf("version file %s is empty", versionFile))
+	}
+	if !strings.Contains(currentVersion, ".") {
+		checkError(fmt.Errorf("version %q in %s does not contain a dot", currentVersion, versionFile))
+	}
+	return currentVersion
+}
+
+// incrementVersion takes a version string and returns the incremented version
+func incrementVersion(currentVersion string) string {
 	vsplit := strings.Split(currentVersion, ".")
+	if len(vsplit) == 0 {
+		checkError(fmt.Errorf("failed to parse version %q", currentVersion))
+	}
 	minorVersion, err := strconv.Atoi(vsplit[len(vsplit)-1])
 	checkError(err)
 	minorVersion++
 	vsplit[len(vsplit)-1] = strconv.Itoa(minorVersion)
-	newVersion := strings.Join(vsplit, ".")
-	err = os.WriteFile(versionFile, []byte(newVersion), 0o755)
+	return strings.Join(vsplit, ".")
+}
+
+// hasUnreleasedContent checks if the changelog has content in the Unreleased section.
+// This function changes the working directory to the repo root.
+func hasUnreleasedContent() (bool, error) {
+	// We need to be in the repo root to read the changelog
+	s.CD("../../..")
+
+	changelogData, err := os.ReadFile(changelogFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to read changelog file %s: %w", changelogFile, err)
+	}
+	changelog := string(changelogData)
+
+	// Split on the Unreleased header
+	parts := strings.Split(changelog, "## [Unreleased]")
+	if len(parts) < 2 {
+		return false, nil // No Unreleased section found
+	}
+
+	// Extract the unreleased section content
+	releaseNotes := extractReleaseNotes(parts[1])
+
+	// Check if there's any meaningful content
+	return len(strings.TrimSpace(releaseNotes)) > 0, nil
+}
+
+// parseArgs parses command-line arguments and returns the version if specified
+func parseArgs() string {
+	var version string
+
+	for _, arg := range os.Args[1:] {
+		switch arg {
+		case "--check-only":
+			checkOnly = true
+		case "--dry-run":
+			dryRun = true
+		default:
+			// Check if it looks like a flag we don't recognize
+			if strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-") {
+				fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", arg)
+				printUsage()
+				os.Exit(1)
+			}
+			// Ensure only a single version argument is provided
+			if version != "" {
+				fmt.Fprintf(os.Stderr, "Multiple version arguments provided: %s and %s\n", version, arg)
+				printUsage()
+				os.Exit(1)
+			}
+			version = arg
+		}
+	}
+
+	return version
+}
+
+// TODO:This can be replaced with "https://github.com/coreos/go-semver/blob/main/semver/semver.go"
+func updateVersion() string {
+	currentVersion := readVersion()
+	newVersion := incrementVersion(currentVersion)
+	err := os.WriteFile(versionFile, []byte(newVersion), 0o755)
 	checkError(err)
 	return newVersion
 }
@@ -48,7 +140,7 @@ func extractReleaseNotes(changelogSection string) string {
 	// Find the next version header (starts with "## v" or "## [")
 	lines := strings.Split(changelogSection, "\n")
 	var releaseLines []string
-	
+
 	for _, line := range lines {
 		// Stop at the next version header
 		if strings.HasPrefix(strings.TrimSpace(line), "## v") || strings.HasPrefix(strings.TrimSpace(line), "## [") {
@@ -56,11 +148,11 @@ func extractReleaseNotes(changelogSection string) string {
 		}
 		releaseLines = append(releaseLines, line)
 	}
-	
+
 	// Join lines and trim empty lines from beginning and end
 	releaseNotes := strings.Join(releaseLines, "\n")
 	releaseNotes = strings.TrimSpace(releaseNotes)
-	
+
 	return releaseNotes
 }
 
@@ -79,43 +171,76 @@ func extractReleaseNotes(changelogSection string) string {
 //}
 
 func main() {
+	// Parse command-line arguments first
+	specifiedVersion := parseArgs()
+
+	// Handle --check-only mode: just check for unreleased content and exit
+	// Note: --check-only takes precedence over --dry-run
+	if checkOnly {
+		hasContent, err := hasUnreleasedContent()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error checking changelog: %v\n", err)
+			os.Exit(1)
+		}
+		if hasContent {
+			println("Unreleased changelog content found")
+			os.Exit(0)
+		} else {
+			println("No unreleased changelog content")
+			os.Exit(1)
+		}
+	}
+
+	// Determine the new version
 	var newVersion string
-	if len(os.Args) > 1 {
-		newVersion = os.Args[1]
-		//currentVersion, err := os.ReadFile(versionFile)
-		//checkError(err)
-		err := os.WriteFile(versionFile, []byte(newVersion), 0o755)
-		checkError(err)
-		//isPointRelease = IsPointRelease(string(currentVersion), newVersion)
+	if specifiedVersion != "" {
+		newVersion = specifiedVersion
+		if dryRun {
+			println("[DRY RUN] Would write version to " + versionFile + ": " + newVersion)
+		} else {
+			err := os.WriteFile(versionFile, []byte(newVersion), 0o755)
+			checkError(err)
+		}
 	} else {
-		newVersion = updateVersion()
+		currentVersion := readVersion()
+		newVersion = incrementVersion(currentVersion)
+		if dryRun {
+			println("[DRY RUN] Would increment version from " + currentVersion + " to " + newVersion)
+		} else {
+			err := os.WriteFile(versionFile, []byte(newVersion), 0o755)
+			checkError(err)
+		}
 	}
 
 	// Update ChangeLog
 	s.CD("../../..")
 
-	// Read in `src/pages/changelog.md`
-	changelogData, err := os.ReadFile("docs/src/content/docs/changelog.mdx")
+	// Read in changelog
+	changelogData, err := os.ReadFile(changelogFile)
 	checkError(err)
 	changelog := string(changelogData)
 	// Split on the line that has `## [Unreleased]`
 	changelogSplit := strings.Split(changelog, "## [Unreleased]")
 	// Get today's date in YYYY-MM-DD format
 	today := time.Now().Format("2006-01-02")
-	
+
 	// Extract release notes from the Unreleased section
 	releaseNotes := extractReleaseNotes(changelogSplit[1])
-	
+
 	// Print JUST the release notes for version tag
 	println("=== RELEASE NOTES FOR " + newVersion + " ===")
 	print(releaseNotes)
 	println("=== END RELEASE NOTES ===")
-	
+
 	// Add the new version to the top of the changelog
 	newChangelog := changelogSplit[0] + "## [Unreleased]\n\n## " + newVersion + " - " + today + changelogSplit[1]
 	// Write the changelog back
-	err = os.WriteFile("docs/src/content/docs/changelog.mdx", []byte(newChangelog), 0o755)
-	checkError(err)
+	if dryRun {
+		println("[DRY RUN] Would update changelog at " + changelogFile)
+	} else {
+		err = os.WriteFile(changelogFile, []byte(newChangelog), 0o755)
+		checkError(err)
+	}
 
 	// TODO: Documentation Versioning and Translations
 


### PR DESCRIPTION
## Summary

Fixes the nightly release workflow failure caused by the release script not supporting the `--check-only` flag.

**The bug:** The nightly release workflow has been calling `go run release.go --check-only` since July 2025, but this flag was never implemented. The script treated `--check-only` as a version string and wrote it to `version.txt`, corrupting subsequent releases with:

```
strconv.Atoi: parsing "--check-only": invalid syntax
```

**The fix:** Adds proper flag parsing to `release.go`:

| Flag | Behavior |
|------|----------|
| `--check-only` | Check if unreleased changelog content exists. Exit 0 if yes, 1 if no. **Does not modify files.** |
| `--dry-run` | Simulate release without making changes. Shows what would happen. |
| Unknown flags | Display usage help instead of silently treating as version |

## Test plan

- [x] `go run release.go --check-only` exits 1 when no unreleased content (correct)
- [x] `go run release.go --dry-run` shows what would be done without modifying files
- [x] `go run release.go --unknown` shows usage help and exits 1
- [x] `version.txt` remains intact after running with flags
- [ ] Nightly workflow should pass after merge

## Related

- Fixes: https://github.com/leaanthony/wails/actions/runs/21555610709/job/62111249087

---
Generated with [Claude Code](https://claude.ai/code)